### PR TITLE
dgeni-packages old version

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
   "dependencies": {
     "canonical-path": "0.0.2",
     "dgeni": "^0.4.2",
-    "dgeni-packages": "^0.11.1"
+    "dgeni-packages": "^0.16.0"
   },
   "devDependencies": {
     "grunt": "^0.4.5",


### PR DESCRIPTION
Updated dgeni-packages dependency to the latest version. This fixes an issue with the write process that causes the output files to be empty on some builds (not every time dgeni is run, only sometimes). Besides which, dgeni-packages version 0.11 is quite old now.
