### PR TITLE
Fixing md-links

### DIFF
--- a/inline-tag-defs/link.js
+++ b/inline-tag-defs/link.js
@@ -15,7 +15,7 @@ module.exports = function linkInlineTagDef(getLinkInfo, createDocMessage) {
           return linkInfo.title;
         }
 
-        return '(' + linkInfo.title + ')[' + linkInfo.url + ']';
+        return '[' + linkInfo.title + '](' + linkInfo.url + ')';
       });
     }
   };

--- a/inline-tag-defs/link.js
+++ b/inline-tag-defs/link.js
@@ -15,7 +15,7 @@ module.exports = function linkInlineTagDef(getLinkInfo, createDocMessage) {
           return linkInfo.title;
         }
 
-        return '[' + linkInfo.title + '](' + linkInfo.url + ')';
+        return '[' + linkInfo.title + '](' + linkInfo.url + '.md)';
       });
     }
   };


### PR DESCRIPTION
@link doesn't work correctly, because the markdown of links is not correct (brackets) and the link has to point to another md-file.